### PR TITLE
nexus-cve-2019-7238

### DIFF
--- a/pocs/nexus-cve-2019-7238.yml
+++ b/pocs/nexus-cve-2019-7238.yml
@@ -12,7 +12,7 @@ rules:
       response.status == 200 && response.body.bcontains(bytes(md5(string(r))))
 detail:
   Affected Version: "nexus<3.15"
-  author: harris2015(https://github.com/hanxiansheng26)
+  author: hanxiansheng26(https://github.com/hanxiansheng26)
   links:
     - https://github.com/jas502n/CVE-2019-7238
     - https://github.com/vulhub/vulhub/tree/master/php/CVE-2018-19518


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
rce
## 测试环境
nexus
## 备注
Affected Version: "nexus<3.15"
  author: hanxiansheng26(https://github.com/hanxiansheng26)
  links:
    - https://github.com/vulhub/vulhub/tree/master/spring/CVE-2016-4977